### PR TITLE
Alter input shape on ImageTrain

### DIFF
--- a/src/BariumImage.py
+++ b/src/BariumImage.py
@@ -275,13 +275,13 @@ while True:
         imagem = np.full((100, 100), -1, dtype=int)
         for i, [x_c, y_c] in enumerate(coordenadas):
             if 0 <= x_c < 100 and 0 <= y_c < 100:
-                imagem[int(x_c),int(y_c)] = i
+                imagem[int(x_c),int(y_c)] = (1 + i ) / 22
         video_imagem[im] = imagem
     video = video_imagem
 
-    x = np.array(x).reshape((x.shape[0], 20, 21, 2))
+    x = np.array(x).reshape((x.shape[0], 20, 100, 100))
 
-    video = (x[(x.shape[0]) - 1]).reshape((1, 20, 21, 2))
+    video = (x[(x.shape[0]) - 1]).reshape((1, 20, 100, 100))
 
     print(video.shape)
 

--- a/src/image_train.py
+++ b/src/image_train.py
@@ -60,7 +60,7 @@ for a in range(x.shape[0]):
         imagem = np.full((100, 100), -1, dtype=int)
         for i, [x_c, y_c] in enumerate(coordenadas):
             if 0 <= x_c < 100 and 0 <= y_c < 100:
-                imagem[int(x_c),int(y_c)] = i
+                imagem[int(x_c),int(y_c)] = (1 + i) / 22
         video_imagem[im] = imagem
     saida[a] = video_imagem
 
@@ -83,8 +83,8 @@ y_encoded = pd.get_dummies(y)
 
 x_train, x_test, y_train, y_test = train_test_split(x, y_encoded, test_size=0.2, random_state=42)
 
-x_train = x_train.reshape(x_train.shape[0], 100, 100, 20)
-x_test = x_test.reshape(x_test.shape[0], 100, 100, 20)
+x_train = x_train.reshape(x_train.shape[0], 20, 100, 100)
+x_test = x_test.reshape(x_test.shape[0], 20, 100, 100)
 
 model = Sequential()
 
@@ -100,7 +100,7 @@ model = Sequential()
 # Modelo mais complexo
 model = Sequential()
 
-model.add(Conv3D(32, (3, 3, 3), activation='relu', input_shape=(100, 100, 20, 1)))
+model.add(Conv3D(32, (3, 3, 3), activation='relu', input_shape=(20, 100, 100, 1)))
 model.add(MaxPooling3D((2, 2, 2)))
 
 model.add(Conv3D(64, (3, 3, 3), activation='relu'))
@@ -111,6 +111,7 @@ model.add(Conv3D(64, (3, 3, 3), activation='relu'))
 model.add(Flatten())
 
 model.add(Dense(64, activation='relu'))
+model.add(Dense(64, activation='sigmoid'))
 model.add(Dense(quantidade_movimentos, activation='softmax'))
 
 model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])
@@ -120,4 +121,4 @@ model.fit(x_train, y_train, epochs=10, batch_size=32, validation_data=(x_test, y
 loss, accuracy = model.evaluate(x_test, y_test)
 print(f"Acurácia do modelo: {accuracy*100:.2f}%")
 
-model.save("../models/modelImage.keras")
+model.save("../models/modelImage2.keras")


### PR DESCRIPTION
In the last pull request, the input shape of the input layer was (100, 1001 20, 1), because I was thinked that tha's means 20 images 100 per 100, but isn't. Now I improve this to correct